### PR TITLE
Added Career Vault to remote job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated list of awesome niche job boards.
 
 ## Remote
 
+* [Career Vault](https://careervault.io/)
 * [We Work Remotely](https://weworkremotely.com/)
 
 ### Aggregator


### PR DESCRIPTION
Check it out here: https://www.careervault.io.

Career Vault posts over 20x more remote jobs than other popular job boards and links applicants directly to the original job posting. It's free for job seekers, doesn't require signing up, and doesn't have any obsolete postings (those are automatically deleted).